### PR TITLE
fix: default empty string & include name in response

### DIFF
--- a/src/database_handler.ts
+++ b/src/database_handler.ts
@@ -58,6 +58,7 @@ export interface SteamInventoryItem {
     instanceid: string;
     amount: string;
     icon_url: string;
+    name: string;
 }
 
 export class Database {


### PR DESCRIPTION
- asset with empty `icon_url` or `name` will not return error instead of returning empty string
- added `name: string` in inventory endpoint response